### PR TITLE
Fix typo in header docs: s/interects/intersects/

### DIFF
--- a/tg.h
+++ b/tg.h
@@ -234,7 +234,7 @@ bool tg_rect_intersects_point(struct tg_rect a, struct tg_point b);
 /// must upcast the ring to a tg_geom, like such:
 ///
 /// ```
-/// tg_geom_interects((struct tg_geom*)ring, geom);
+/// tg_geom_intersects((struct tg_geom*)ring, geom);
 /// ```
 /// @{
 struct tg_ring *tg_ring_new(const struct tg_point *points, int npoints);
@@ -280,7 +280,7 @@ double tg_ring_perimeter(const struct tg_ring *ring);
 /// must upcast the line to a tg_geom, like such:
 ///
 /// ```
-/// tg_geom_interects((struct tg_geom*)line, geom);
+/// tg_geom_intersects((struct tg_geom*)line, geom);
 /// ```
 /// @{
 struct tg_line *tg_line_new(const struct tg_point *points, int npoints);
@@ -320,7 +320,7 @@ double tg_line_length(const struct tg_line *line);
 /// must upcast the poly to a tg_geom, like such:
 ///
 /// ```
-/// tg_geom_interects((struct tg_geom*)poly, geom);
+/// tg_geom_intersects((struct tg_geom*)poly, geom);
 /// ```
 /// @{
 struct tg_poly *tg_poly_new(const struct tg_ring *exterior, const struct tg_ring *const holes[], int nholes);


### PR DESCRIPTION
Please do not open a pull request without first filing an issue and/or discussing the feature directly with me.

### Please ensure you adhere to every item in this list

This is not a feature.  I don't believe it needs pre-approval.

- [ ] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [x] I have added all necessary tests

### Describe your changes

The docs in the header file include a code typo, where the `tg_geom_intersects` function is missing the first s

### Issue number and link

N/A. The fix is the bug report.
