### PR TITLE
Fix compiler warnings

### DIFF
--- a/tg.c
+++ b/tg.c
@@ -403,8 +403,6 @@ TG_EXTERN bool tg_segment_intersects_segment(struct tg_segment a,
 TG_EXTERN bool tg_poly_covers_xy(const struct tg_poly *a, double x, double y);
 TG_EXTERN bool tg_poly_touches_line(const struct tg_poly *a,
     const struct tg_line *b);
-TG_EXTERN bool tg_poly_coveredby_poly(const struct tg_poly *a,
-    const struct tg_poly *b);
 TG_EXTERN bool tg_poly_covers_point(const struct tg_poly *a, struct tg_point b);
 TG_EXTERN bool tg_poly_covers_rect(const struct tg_poly *a, struct tg_rect b);
 TG_EXTERN bool tg_poly_covers_line(const struct tg_poly *a,
@@ -15448,7 +15446,6 @@ void tg_geom_setnoheap(struct tg_geom *geom) {
 /// Parse GeoBIN binary using provided indexing option.
 /// @param geobin GeoBIN data
 /// @param len Length of data
-/// @param ix Indexing option, e.g. TG_NONE, TG_NATURAL, TG_YSTRIPES
 /// @returns A geometry or an error. Use tg_geom_error() after parsing to check
 /// for errors. 
 /// @see tg_parse_geobin_ix()


### PR DESCRIPTION

Please do not open a pull request without first filing an issue and/or discussing the feature directly with me.

### Please ensure you adhere to every item in this list

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [x] I have added all necessary tests

### Describe your changes
When using tg.c as TG_STATIC, there are two warnings: from a declared function which isn't implemented and an extra argument in the documentation.

Function with only a prototype (when compiled with `gcc -Wall -Werror`): tg.c:406:16: warning: 'tg_poly_coveredby_poly' declared 'static' but never defined [-Wunused-function]
  406 | TG_EXTERN bool tg_poly_coveredby_poly(const struct tg_poly *a,
      |                ^~~~~~~~~~~~~~~~~~~~~~

Documentation with an extra argument (when compiled with clang -Wall -Wdocumentation -Werror):
tg.c:15451:12: warning: parameter 'ix' not found in the function declaration [-Wdocumentation]
 15451 | /// @param ix Indexing option, e.g. TG_NONE, TG_NATURAL, TG_YSTRIPES
       |            ^~


### Issue number and link

See issue #11 
