### PR TITLE
Force WKB parsing to allocate points on ARMv7

### DIFF
--- a/tg.c
+++ b/tg.c
@@ -13321,6 +13321,14 @@ static const char *wkb_invalid_err(void) {
 
 #define PARSE_FAIL SIZE_MAX
 
+static bool wkb_is_aligned(const void *ptr)
+{
+#if defined(__x86_64__) || defined(__aarch64__)
+    return true;
+#endif
+    return (uintptr_t)ptr % sizeof(double) == 0;
+}
+
 // returns the updated wkb index.
 static size_t parse_wkb_posns(enum base base, int dims, 
     const uint8_t *wkb, size_t len, size_t i, bool swap,
@@ -13333,7 +13341,7 @@ static size_t parse_wkb_posns(enum base base, int dims,
     uint32_t count;
     read_uint32(count);
     if (count == 0) return i;
-    if (dims == 2 && !swap && len-i >= count*2*8) {
+    if (dims == 2 && !swap && len-i >= count*2*8 && wkb_is_aligned(wkb+i)) {
         // Use the point data directly. No allocations. 
         *points = (void*)(wkb+i);
         *npoints = count;


### PR DESCRIPTION

Please do not open a pull request without first filing an issue and/or discussing the feature directly with me.

### Please ensure you adhere to every item in this list

- [x] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [x] I have added all necessary tests

### Describe your changes

The WKB struct present in GeoBIN files isn't always memory aligned which doesn't work on ARMv7 cpus and leads to bus errors. This fix forces the points to be read with the read_posn function instead.

Tested on x86_64, ARMv7, and aarch64.

### Issue number and link

See issue #12 
