### PR TITLE
Fix YSTRIPES indexing bug for segments at polygon top edge

### DIFF
--- a/tg.c
+++ b/tg.c
@@ -1694,8 +1694,8 @@ static bool process_ystripes(struct tg_ring *ring) {
         double ymax = fmax0(ring->points[i].y, ring->points[i+1].y);
         int min = (ymin - ring->rect.min.y) / height * (double)nstripes;
         int max = (ymax - ring->rect.min.y) / height * (double)nstripes;
-        min = fmax0(min, 0);
         max = fmin0(max, nstripes-1);
+        min = fmin0(fmax0(min, 0), max);
         for (int j = min; j <= max; j++) {
             ycounts[j]++;
             nmap++;
@@ -1727,8 +1727,8 @@ static bool process_ystripes(struct tg_ring *ring) {
         double ymax = fmax0(ring->points[i].y, ring->points[i+1].y);
         int min = (ymin - ring->rect.min.y) / height * (double)nstripes;
         int max = (ymax - ring->rect.min.y) / height * (double)nstripes;
-        min = fmax0(min, 0);
         max = fmin0(max, nstripes-1);
+        min = fmin0(fmax0(min, 0), max);
         for (int j = min; j <= max; j++) {
             struct ystripe *stripe = &ystripes->stripes[j];
             stripe->indexes[stripe->count++] = i;


### PR DESCRIPTION
### Please ensure you adhere to every item in this list

- [*] This PR was pre-approved by the project maintainer
- [*] I have self-reviewed the code
- [*] I have added all necessary tests

### Describe your changes

Points touching the top edge of polygons incorrectly return false for intersection tests when using TG_YSTRIPES indexing, while correctly returning true with TG_DEFAULT indexing (see #16 for details). This is caused by a problem in `process_ystripes()` when processing horizontal segments at the exact top boundary. The segment will be missed and never intersects with other geometries. This patch fixes this problem by ensuring that the top edge get properly assigned to the highest stripe.

### Issue number and link

Closes #16.
