### PR TITLE
New headers needed for compiling the Python bindings module

### DIFF
--- a/tg.h
+++ b/tg.h
@@ -34,11 +34,13 @@ struct tg_rect {
     struct tg_point min;
     struct tg_point max;
 };
+typedef struct tg_rect tg_rect;
 
 struct tg_line;  ///< Find the description in the tg.c file.
 struct tg_ring;  ///< Find the description in the tg.c file.
 struct tg_poly;  ///< Find the description in the tg.c file.
 struct tg_geom;  ///< Find the description in the tg.c file.
+typedef struct tg_geom tg_geom; // Add typedef for opaque struct
 
 /// Geometry types.
 ///


### PR DESCRIPTION
Please do not open a pull request without first filing an issue and/or discussing the feature directly with me.

### Please ensure you adhere to every item in this list

- [] This PR was pre-approved by the project maintainer
- [x] I have self-reviewed the code
- [] I have added all necessary tests

### Describe your changes
I need these two lines to be able to generate the Python bindings

Please provide detailed description of the changes.
Those fix the two errors I share here:
```shell
(.venv) ~/r/tg (main|✚1) $ python setup.py build_ext --inplace
Compiling tg_py.pyx because it changed.
[1/1] Cythonizing tg_py.pyx
running build_ext
building 'tg_py' extension
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I. -I/home/employee/repos/tg/.venv/include -I/usr/include/python3.13 -c tg.c -o build/temp.linux-x86_64-cpython-313/tg.o
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I. -I/home/employee/repos/tg/.venv/include -I/usr/include/python3.13 -c tg_py.c -o build/temp.linux-x86_64-cpython-313/tg_py.o
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_10rect’:
tg_py.c:3495:3: error: unknown type name ‘tg_rect’; use ‘struct’ keyword to refer to the type
 3495 |   tg_rect __pyx_v_r;
      |   ^~~~~~~
      |   struct 
tg_py.c:3514:15: error: incompatible types when assigning to type ‘int’ from type ‘struct tg_rect’
 3514 |   __pyx_v_r = tg_geom_rect(__pyx_v_self->geom);
      |               ^~~~~~~~~~~~
tg_py.c:3524:43: error: request for member ‘min’ in something not a structure or union
 3524 |   __pyx_t_1 = PyFloat_FromDouble(__pyx_v_r.min.x); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 93, __pyx_L1_error)
      |                                           ^
tg_py.c:3526:43: error: request for member ‘min’ in something not a structure or union
 3526 |   __pyx_t_2 = PyFloat_FromDouble(__pyx_v_r.min.y); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 93, __pyx_L1_error)
      |                                           ^
tg_py.c:3536:43: error: request for member ‘max’ in something not a structure or union
 3536 |   __pyx_t_2 = PyFloat_FromDouble(__pyx_v_r.max.x); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 93, __pyx_L1_error)
      |                                           ^
tg_py.c:3538:43: error: request for member ‘max’ in something not a structure or union
 3538 |   __pyx_t_1 = PyFloat_FromDouble(__pyx_v_r.max.y); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 93, __pyx_L1_error)
      |                                           ^
tg_py.c:3495:11: warning: variable ‘__pyx_v_r’ set but not used [-Wunused-but-set-variable]
 3495 |   tg_rect __pyx_v_r;
      |           ^~~~~~~~~
error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
(.venv) ~/r/tg (main|✚1) [0|1]$ python setup.py build_ext --inplace
running build_ext
building 'tg_py' extension
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I. -I/home/employee/repos/tg/.venv/include -I/usr/include/python3.13 -c tg.c -o build/temp.linux-x86_64-cpython-313/tg.o
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I. -I/home/employee/repos/tg/.venv/include -I/usr/include/python3.13 -c tg_py.c -o build/temp.linux-x86_64-cpython-313/tg_py.o
tg_py.c:1527:3: error: unknown type name ‘tg_geom’
 1527 |   tg_geom *geom;
      |   ^~~~~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry___cinit__’:
tg_py.c:2764:3: error: unknown type name ‘tg_geom’; use ‘struct’ keyword to refer to the type
 2764 |   tg_geom *__pyx_v_ptr;
      |   ^~~~~~~
      |   struct 
tg_py.c:2800:21: error: ‘tg_geom’ undeclared (first use in this function)
 2800 |     __pyx_v_ptr = ((tg_geom *)__pyx_v_geom_ptr);
      |                     ^~~~~~~
tg_py.c:2800:21: note: each undeclared identifier is reported only once for each function it appears in
tg_py.c:2800:30: error: expected expression before ‘)’ token
 2800 |     __pyx_v_ptr = ((tg_geom *)__pyx_v_geom_ptr);
      |                              ^
tg_py.c:2854:24: error: assignment to ‘int *’ from incompatible pointer type ‘struct tg_geom *’ [-Wincompatible-pointer-types]
 2854 |     __pyx_v_self->geom = tg_parse_wkt(__pyx_t_3);
      |                        ^
tg_py.c:2891:24: error: assignment to ‘int *’ from incompatible pointer type ‘struct tg_geom *’ [-Wincompatible-pointer-types]
 2891 |     __pyx_v_self->geom = tg_parse_geojson(__pyx_t_4);
      |                        ^
tg_py.c:2928:24: error: assignment to ‘int *’ from incompatible pointer type ‘struct tg_geom *’ [-Wincompatible-pointer-types]
 2928 |     __pyx_v_self->geom = tg_parse_hex(__pyx_t_5);
      |                        ^
tg_py.c:2974:43: error: passing argument 1 of ‘tg_geom_error’ from incompatible pointer type [-Wincompatible-pointer-types]
 2974 |   __pyx_v_err = tg_geom_error(__pyx_v_self->geom);
      |                               ~~~~~~~~~~~~^~~~~~
      |                                           |
      |                                           int *
In file included from tg_py.c:1140:
tg.h:167:49: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  167 | const char *tg_geom_error(const struct tg_geom *geom);
      |                           ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_6type’:
tg_py.c:3322:64: error: passing argument 1 of ‘tg_geom_typeof’ from incompatible pointer type [-Wincompatible-pointer-types]
 3322 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_typeof(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 85, __pyx_L1_error)
      |                                                    ~~~~~~~~~~~~^~~~~~
      |                                                                |
      |                                                                int *
tg.h:98:56: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
   98 | enum tg_geom_type tg_geom_typeof(const struct tg_geom *geom);
      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_8type_string’:
tg_py.c:3416:62: error: passing argument 1 of ‘tg_geom_typeof’ from incompatible pointer type [-Wincompatible-pointer-types]
 3416 |   __pyx_t_1 = tg_geom_type_string(tg_geom_typeof(__pyx_v_self->geom));
      |                                                  ~~~~~~~~~~~~^~~~~~
      |                                                              |
      |                                                              int *
tg.h:98:56: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
   98 | enum tg_geom_type tg_geom_typeof(const struct tg_geom *geom);
      |                                  ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_10rect’:
tg_py.c:3514:40: error: passing argument 1 of ‘tg_geom_rect’ from incompatible pointer type [-Wincompatible-pointer-types]
 3514 |   __pyx_v_r = tg_geom_rect(__pyx_v_self->geom);
      |                            ~~~~~~~~~~~~^~~~~~
      |                                        |
      |                                        int *
tg.h:100:51: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  100 | struct tg_rect tg_geom_rect(const struct tg_geom *geom);
      |                             ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_12is_feature’:
tg_py.c:3650:68: error: passing argument 1 of ‘tg_geom_is_feature’ from incompatible pointer type [-Wincompatible-pointer-types]
 3650 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_is_feature(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 96, __pyx_L1_error)
      |                                                        ~~~~~~~~~~~~^~~~~~
      |                                                                    |
      |                                                                    int *
tg.h:101:47: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  101 | bool tg_geom_is_feature(const struct tg_geom *geom);
      |                         ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_14is_featurecollection’:
tg_py.c:3747:78: error: passing argument 1 of ‘tg_geom_is_featurecollection’ from incompatible pointer type [-Wincompatible-pointer-types]
 3747 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_is_featurecollection(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 99, __pyx_L1_error)
      |                                                                  ~~~~~~~~~~~~^~~~~~
      |                                                                              |
      |                                                                              int *
tg.h:102:57: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  102 | bool tg_geom_is_featurecollection(const struct tg_geom *geom);
      |                                   ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_16is_empty’:
tg_py.c:3844:66: error: passing argument 1 of ‘tg_geom_is_empty’ from incompatible pointer type [-Wincompatible-pointer-types]
 3844 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_is_empty(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 102, __pyx_L1_error)
      |                                                      ~~~~~~~~~~~~^~~~~~
      |                                                                  |
      |                                                                  int *
tg.h:115:45: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  115 | bool tg_geom_is_empty(const struct tg_geom *geom);
      |                       ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_18dims’:
tg_py.c:3940:62: error: passing argument 1 of ‘tg_geom_dims’ from incompatible pointer type [-Wincompatible-pointer-types]
 3940 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_dims(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 105, __pyx_L1_error)
      |                                                  ~~~~~~~~~~~~^~~~~~
      |                                                              |
      |                                                              int *
tg.h:116:40: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  116 | int tg_geom_dims(const struct tg_geom *geom);
      |                  ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_20has_z’:
tg_py.c:4033:63: error: passing argument 1 of ‘tg_geom_has_z’ from incompatible pointer type [-Wincompatible-pointer-types]
 4033 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_has_z(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 108, __pyx_L1_error)
      |                                                   ~~~~~~~~~~~~^~~~~~
      |                                                               |
      |                                                               int *
tg.h:117:42: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  117 | bool tg_geom_has_z(const struct tg_geom *geom);
      |                    ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_22has_m’:
tg_py.c:4130:63: error: passing argument 1 of ‘tg_geom_has_m’ from incompatible pointer type [-Wincompatible-pointer-types]
 4130 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_has_m(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 111, __pyx_L1_error)
      |                                                   ~~~~~~~~~~~~^~~~~~
      |                                                               |
      |                                                               int *
tg.h:118:42: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  118 | bool tg_geom_has_m(const struct tg_geom *geom);
      |                    ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_24z’:
tg_py.c:4226:56: error: passing argument 1 of ‘tg_geom_z’ from incompatible pointer type [-Wincompatible-pointer-types]
 4226 |   __pyx_t_1 = PyFloat_FromDouble(tg_geom_z(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 114, __pyx_L1_error)
      |                                            ~~~~~~~~~~~~^~~~~~
      |                                                        |
      |                                                        int *
tg.h:119:40: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  119 | double tg_geom_z(const struct tg_geom *geom);
      |                  ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_26m’:
tg_py.c:4318:56: error: passing argument 1 of ‘tg_geom_m’ from incompatible pointer type [-Wincompatible-pointer-types]
 4318 |   __pyx_t_1 = PyFloat_FromDouble(tg_geom_m(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 117, __pyx_L1_error)
      |                                            ~~~~~~~~~~~~^~~~~~
      |                                                        |
      |                                                        int *
tg.h:120:40: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  120 | double tg_geom_m(const struct tg_geom *geom);
      |                  ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_28memsize’:
tg_py.c:4410:67: error: passing argument 1 of ‘tg_geom_memsize’ from incompatible pointer type [-Wincompatible-pointer-types]
 4410 |   __pyx_t_1 = __Pyx_PyLong_FromSize_t(tg_geom_memsize(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 120, __pyx_L1_error)
      |                                                       ~~~~~~~~~~~~^~~~~~
      |                                                                   |
      |                                                                   int *
tg.h:123:46: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  123 | size_t tg_geom_memsize(const struct tg_geom *geom);
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_30num_points’:
tg_py.c:4502:68: error: passing argument 1 of ‘tg_geom_num_points’ from incompatible pointer type [-Wincompatible-pointer-types]
 4502 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_num_points(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 123, __pyx_L1_error)
      |                                                        ~~~~~~~~~~~~^~~~~~
      |                                                                    |
      |                                                                    int *
tg.h:106:46: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  106 | int tg_geom_num_points(const struct tg_geom *geom);
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_32num_lines’:
tg_py.c:4594:67: error: passing argument 1 of ‘tg_geom_num_lines’ from incompatible pointer type [-Wincompatible-pointer-types]
 4594 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_num_lines(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 126, __pyx_L1_error)
      |                                                       ~~~~~~~~~~~~^~~~~~
      |                                                                   |
      |                                                                   int *
tg.h:108:45: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  108 | int tg_geom_num_lines(const struct tg_geom *geom);
      |                       ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_34num_polys’:
tg_py.c:4686:67: error: passing argument 1 of ‘tg_geom_num_polys’ from incompatible pointer type [-Wincompatible-pointer-types]
 4686 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_num_polys(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 129, __pyx_L1_error)
      |                                                       ~~~~~~~~~~~~^~~~~~
      |                                                                   |
      |                                                                   int *
tg.h:110:45: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  110 | int tg_geom_num_polys(const struct tg_geom *geom);
      |                       ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_36num_geometries’:
tg_py.c:4778:72: error: passing argument 1 of ‘tg_geom_num_geometries’ from incompatible pointer type [-Wincompatible-pointer-types]
 4778 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_num_geometries(__pyx_v_self->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 132, __pyx_L1_error)
      |                                                            ~~~~~~~~~~~~^~~~~~
      |                                                                        |
      |                                                                        int *
tg.h:112:50: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  112 | int tg_geom_num_geometries(const struct tg_geom *geom);
      |                            ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_38equals’:
tg_py.c:4924:64: error: passing argument 1 of ‘tg_geom_equals’ from incompatible pointer type [-Wincompatible-pointer-types]
 4924 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_equals(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 135, __pyx_L1_error)
      |                                                    ~~~~~~~~~~~~^~~~~~
      |                                                                |
      |                                                                int *
tg.h:133:43: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  133 | bool tg_geom_equals(const struct tg_geom *a, const struct tg_geom *b);
      |                     ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:4924:85: error: passing argument 2 of ‘tg_geom_equals’ from incompatible pointer type [-Wincompatible-pointer-types]
 4924 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_equals(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 135, __pyx_L1_error)
      |                                                                        ~~~~~~~~~~~~~^~~~~~
      |                                                                                     |
      |                                                                                     int *
tg.h:133:68: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  133 | bool tg_geom_equals(const struct tg_geom *a, const struct tg_geom *b);
      |                                              ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_40disjoint’:
tg_py.c:5074:66: error: passing argument 1 of ‘tg_geom_disjoint’ from incompatible pointer type [-Wincompatible-pointer-types]
 5074 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_disjoint(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 138, __pyx_L1_error)
      |                                                      ~~~~~~~~~~~~^~~~~~
      |                                                                  |
      |                                                                  int *
tg.h:135:45: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  135 | bool tg_geom_disjoint(const struct tg_geom *a, const struct tg_geom *b);
      |                       ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5074:87: error: passing argument 2 of ‘tg_geom_disjoint’ from incompatible pointer type [-Wincompatible-pointer-types]
 5074 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_disjoint(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 138, __pyx_L1_error)
      |                                                                          ~~~~~~~~~~~~~^~~~~~
      |                                                                                       |
      |                                                                                       int *
tg.h:135:70: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  135 | bool tg_geom_disjoint(const struct tg_geom *a, const struct tg_geom *b);
      |                                                ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_42contains’:
tg_py.c:5224:66: error: passing argument 1 of ‘tg_geom_contains’ from incompatible pointer type [-Wincompatible-pointer-types]
 5224 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_contains(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 141, __pyx_L1_error)
      |                                                      ~~~~~~~~~~~~^~~~~~
      |                                                                  |
      |                                                                  int *
tg.h:136:45: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  136 | bool tg_geom_contains(const struct tg_geom *a, const struct tg_geom *b);
      |                       ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5224:87: error: passing argument 2 of ‘tg_geom_contains’ from incompatible pointer type [-Wincompatible-pointer-types]
 5224 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_contains(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 141, __pyx_L1_error)
      |                                                                          ~~~~~~~~~~~~~^~~~~~
      |                                                                                       |
      |                                                                                       int *
tg.h:136:70: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  136 | bool tg_geom_contains(const struct tg_geom *a, const struct tg_geom *b);
      |                                                ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_44within’:
tg_py.c:5374:64: error: passing argument 1 of ‘tg_geom_within’ from incompatible pointer type [-Wincompatible-pointer-types]
 5374 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_within(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 144, __pyx_L1_error)
      |                                                    ~~~~~~~~~~~~^~~~~~
      |                                                                |
      |                                                                int *
tg.h:137:43: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  137 | bool tg_geom_within(const struct tg_geom *a, const struct tg_geom *b);
      |                     ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5374:85: error: passing argument 2 of ‘tg_geom_within’ from incompatible pointer type [-Wincompatible-pointer-types]
 5374 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_within(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 144, __pyx_L1_error)
      |                                                                        ~~~~~~~~~~~~~^~~~~~
      |                                                                                     |
      |                                                                                     int *
tg.h:137:68: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  137 | bool tg_geom_within(const struct tg_geom *a, const struct tg_geom *b);
      |                                              ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_46covers’:
tg_py.c:5524:64: error: passing argument 1 of ‘tg_geom_covers’ from incompatible pointer type [-Wincompatible-pointer-types]
 5524 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_covers(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 147, __pyx_L1_error)
      |                                                    ~~~~~~~~~~~~^~~~~~
      |                                                                |
      |                                                                int *
tg.h:138:43: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  138 | bool tg_geom_covers(const struct tg_geom *a, const struct tg_geom *b);
      |                     ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5524:85: error: passing argument 2 of ‘tg_geom_covers’ from incompatible pointer type [-Wincompatible-pointer-types]
 5524 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_covers(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 147, __pyx_L1_error)
      |                                                                        ~~~~~~~~~~~~~^~~~~~
      |                                                                                     |
      |                                                                                     int *
tg.h:138:68: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  138 | bool tg_geom_covers(const struct tg_geom *a, const struct tg_geom *b);
      |                                              ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_48coveredby’:
tg_py.c:5674:67: error: passing argument 1 of ‘tg_geom_coveredby’ from incompatible pointer type [-Wincompatible-pointer-types]
 5674 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_coveredby(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 150, __pyx_L1_error)
      |                                                       ~~~~~~~~~~~~^~~~~~
      |                                                                   |
      |                                                                   int *
tg.h:139:46: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  139 | bool tg_geom_coveredby(const struct tg_geom *a, const struct tg_geom *b);
      |                        ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5674:88: error: passing argument 2 of ‘tg_geom_coveredby’ from incompatible pointer type [-Wincompatible-pointer-types]
 5674 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_coveredby(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 150, __pyx_L1_error)
      |                                                                           ~~~~~~~~~~~~~^~~~~~
      |                                                                                        |
      |                                                                                        int *
tg.h:139:71: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  139 | bool tg_geom_coveredby(const struct tg_geom *a, const struct tg_geom *b);
      |                                                 ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_50touches’:
tg_py.c:5824:65: error: passing argument 1 of ‘tg_geom_touches’ from incompatible pointer type [-Wincompatible-pointer-types]
 5824 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_touches(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 153, __pyx_L1_error)
      |                                                     ~~~~~~~~~~~~^~~~~~
      |                                                                 |
      |                                                                 int *
tg.h:140:44: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  140 | bool tg_geom_touches(const struct tg_geom *a, const struct tg_geom *b);
      |                      ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5824:86: error: passing argument 2 of ‘tg_geom_touches’ from incompatible pointer type [-Wincompatible-pointer-types]
 5824 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_touches(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 153, __pyx_L1_error)
      |                                                                         ~~~~~~~~~~~~~^~~~~~
      |                                                                                      |
      |                                                                                      int *
tg.h:140:69: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  140 | bool tg_geom_touches(const struct tg_geom *a, const struct tg_geom *b);
      |                                               ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_52intersects’:
tg_py.c:5974:68: error: passing argument 1 of ‘tg_geom_intersects’ from incompatible pointer type [-Wincompatible-pointer-types]
 5974 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_intersects(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 156, __pyx_L1_error)
      |                                                        ~~~~~~~~~~~~^~~~~~
      |                                                                    |
      |                                                                    int *
tg.h:134:47: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  134 | bool tg_geom_intersects(const struct tg_geom *a, const struct tg_geom *b);
      |                         ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c:5974:89: error: passing argument 2 of ‘tg_geom_intersects’ from incompatible pointer type [-Wincompatible-pointer-types]
 5974 |   __pyx_t_1 = __Pyx_PyLong_From_int(tg_geom_intersects(__pyx_v_self->geom, __pyx_v_other->geom)); if (unlikely(!__pyx_t_1)) __PYX_ERR(0, 156, __pyx_L1_error)
      |                                                                            ~~~~~~~~~~~~~^~~~~~
      |                                                                                         |
      |                                                                                         int *
tg.h:134:72: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  134 | bool tg_geom_intersects(const struct tg_geom *a, const struct tg_geom *b);
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~^
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_54to_wkt’:
tg_py.c:6071:39: error: passing argument 1 of ‘tg_geom_wkt’ from incompatible pointer type [-Wincompatible-pointer-types]
 6071 |   __pyx_v_n = tg_geom_wkt(__pyx_v_self->geom, __pyx_v_buf, 0x1000);
      |                           ~~~~~~~~~~~~^~~~~~
      |                                       |
      |                                       int *
tg.h:177:42: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  177 | size_t tg_geom_wkt(const struct tg_geom *geom, char *dst, size_t n);
      |                    ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_56to_geojson’:
tg_py.c:6174:43: error: passing argument 1 of ‘tg_geom_geojson’ from incompatible pointer type [-Wincompatible-pointer-types]
 6174 |   __pyx_v_n = tg_geom_geojson(__pyx_v_self->geom, __pyx_v_buf, 0x1000);
      |                               ~~~~~~~~~~~~^~~~~~
      |                                           |
      |                                           int *
tg.h:176:46: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  176 | size_t tg_geom_geojson(const struct tg_geom *geom, char *dst, size_t n);
      |                        ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_58to_wkb’:
tg_py.c:6281:39: error: passing argument 1 of ‘tg_geom_wkb’ from incompatible pointer type [-Wincompatible-pointer-types]
 6281 |   __pyx_v_n = tg_geom_wkb(__pyx_v_self->geom, __pyx_v_buf, 0x1000);
      |                           ~~~~~~~~~~~~^~~~~~
      |                                       |
      |                                       int *
tg.h:178:42: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  178 | size_t tg_geom_wkb(const struct tg_geom *geom, uint8_t *dst, size_t n);
      |                    ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_60to_hex’:
tg_py.c:6400:39: error: passing argument 1 of ‘tg_geom_hex’ from incompatible pointer type [-Wincompatible-pointer-types]
 6400 |   __pyx_v_n = tg_geom_hex(__pyx_v_self->geom, __pyx_v_buf, 0x1000);
      |                           ~~~~~~~~~~~~^~~~~~
      |                                       |
      |                                       int *
tg.h:179:42: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  179 | size_t tg_geom_hex(const struct tg_geom *geom, char *dst, size_t n);
      |                    ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_62to_geobin’:
tg_py.c:6507:42: error: passing argument 1 of ‘tg_geom_geobin’ from incompatible pointer type [-Wincompatible-pointer-types]
 6507 |   __pyx_v_n = tg_geom_geobin(__pyx_v_self->geom, __pyx_v_buf, 0x1000);
      |                              ~~~~~~~~~~~~^~~~~~
      |                                          |
      |                                          int *
tg.h:180:45: note: expected ‘const struct tg_geom *’ but argument is of type ‘int *’
  180 | size_t tg_geom_geobin(const struct tg_geom *geom, uint8_t *dst, size_t n);
      |                       ~~~~~~~~~~~~~~~~~~~~~~^~~~
tg_py.c: In function ‘__pyx_pf_5tg_py_8Geometry_64__dealloc__’:
tg_py.c:6596:30: error: passing argument 1 of ‘tg_geom_free’ from incompatible pointer type [-Wincompatible-pointer-types]
 6596 |     tg_geom_free(__pyx_v_self->geom);
      |                  ~~~~~~~~~~~~^~~~~~
      |                              |
      |                              int *
tg.h:90:35: note: expected ‘struct tg_geom *’ but argument is of type ‘int *’
   90 | void tg_geom_free(struct tg_geom *geom);
      |                   ~~~~~~~~~~~~~~~~^~~~
error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
(.venv) ~/r/tg (main|✚1) [0|1]$ python setup.py build_ext --inplace
running build_ext
building 'tg_py' extension
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I. -I/home/employee/repos/tg/.venv/include -I/usr/include/python3.13 -c tg.c -o build/temp.linux-x86_64-cpython-313/tg.o
x86_64-linux-gnu-gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I. -I/home/employee/repos/tg/.venv/include -I/usr/include/python3.13 -c tg_py.c -o build/temp.linux-x86_64-cpython-313/tg_py.o
x86_64-linux-gnu-gcc -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -g -fwrapv -O2 build/temp.linux-x86_64-cpython-313/tg.o build/temp.linux-x86_64-cpython-313/tg_py.o -L/usr/lib/x86_64-linux-gnu -o build/lib.linux-x86_64-cpython-313/tg_py.cpython-313-x86_64-linux-gnu.so
copying build/lib.linux-x86_64-cpython-313/tg_py.cpython-313-x86_64-linux-gnu.so -> 
```


### Issue number and link
Fix for #8 

Pull request require a prior issue with discussion. 
Include the issue number of link here.
