### PR TITLE
Fix typos with codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It's designed for programs that need real-time geospatial, such as geofencing, m
 
 ## Goals
 
-The main goal of TG is to provide the fastest, most memory efficent geometry library for the purpose of monitoring spatial relationships, specifically operations like point-in-polygon and geometry intersect.
+The main goal of TG is to provide the fastest, most memory efficient geometry library for the purpose of monitoring spatial relationships, specifically operations like point-in-polygon and geometry intersect.
 
 It's a non-goal for TG to be a full GIS library. Consider [GEOS](https://libgeos.org) if you need GIS algorithms like generating a convex hull or voronoi diagram.
 

--- a/deps/fp.c
+++ b/deps/fp.c
@@ -2473,7 +2473,7 @@ static size_t fp_utoa(union fpoint fpoint, int bits, char fmt,
 ///
 /// Returns the number of characters, not including the null-terminator, needed
 /// to store the double into the C string buffer.
-/// If the returned length is greater than nbytes-1, then only a parital copy
+/// If the returned length is greater than nbytes-1, then only a partial copy
 /// occurred.
 /// 
 /// The format is one of 
@@ -2493,7 +2493,7 @@ FP_EXTERN size_t fp_dtoa(double d, char fmt, char dst[], size_t n) {
 ///
 /// Returns the number of characters, not including the null-terminator, needed
 /// to store the float into the C string buffer.
-/// If the returned length is greater than nbytes-1, then only a parital copy
+/// If the returned length is greater than nbytes-1, then only a partial copy
 /// occurred.
 /// 
 /// The format is one of 

--- a/deps/json.h
+++ b/deps/json.h
@@ -77,7 +77,7 @@ enum json_type json_type(struct json json);
 // json_raw returns the start of the raw json data.
 // 
 // This function may return NULL if the input is non-existent. Also there is
-// no guarentee that this data will be null-terminated C string. If you want to
+// no guarantee that this data will be null-terminated C string. If you want to
 // retain this data for longer that the data from the original 'json_parse'
 // call then you should copy it first, such as:
 // 
@@ -131,7 +131,7 @@ bool json_string_is_escaped(struct json json);
 //
 // Returns the number of characters, not including the null-terminator, needed
 // to store the JSON into the C string buffer.
-// If the returned length is greater than nbytes-1, then only a parital copy
+// If the returned length is greater than nbytes-1, then only a partial copy
 // occurred, for example:
 //    
 //    char buf[64];
@@ -194,7 +194,7 @@ bool json_bool(struct json json);
 //
 // Returns the number of characters, not including the null-terminator, needed
 // to store the escaped JSON string in the C string buffer.
-// If the returned length is greater than n-1, then only a parital copy
+// If the returned length is greater than n-1, then only a partial copy
 // occurred. In other words the 
 size_t json_escape(const char *str, char *escaped, size_t n); 
 size_t json_escapen(const char *str, size_t len, char *escaped, size_t n); 

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,7 +12,7 @@ For a more general overview please see the project
 
 ## Table of contents
 
-- [Programing notes](#programing-notes)
+- [Programming notes](#programing-notes)
 - [Structs](#structs)
 - [Objects](#objects)
 - [Enums](#enums)
@@ -30,7 +30,7 @@ For a more general overview please see the project
 - [Polygon functions](#polygon-functions)
 - [Global environment](#global-environment)
 
-## Programing notes
+## Programming notes
 
 #### Pure functions
 
@@ -472,7 +472,7 @@ struct tg_rect {
     struct tg_point max;
 };
 ```
-A rectangle defined by a minimum and maximum coordinates. Returned by the [tg_geom_rect()](#group___geometry_accessors_1ga68d67f900b847ae08e6515a620f4f657), [tg_ring_rect()](#group___ring_funcs_1ga64086c935039b1f0fcd8633be763427d), and other *_rect() functions for getting a geometry's minumum bounding rectangle. Also used internally for geometry indexing. 
+A rectangle defined by a minimum and maximum coordinates. Returned by the [tg_geom_rect()](#group___geometry_accessors_1ga68d67f900b847ae08e6515a620f4f657), [tg_ring_rect()](#group___ring_funcs_1ga64086c935039b1f0fcd8633be763427d), and other *_rect() functions for getting a geometry's minimum bounding rectangle. Also used internally for geometry indexing. 
 
 **See also**
 
@@ -586,7 +586,7 @@ struct tg_geom;
 ```
 A geometry is the common generic type that can represent a Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or GeometryCollection.
 
-For geometries that are derived from GeoJSON, they may have addtional attributes such as being a Feature or a FeatureCollection; or include extra json fields.
+For geometries that are derived from GeoJSON, they may have additional attributes such as being a Feature or a FeatureCollection; or include extra json fields.
 
 **Creating**
 
@@ -1039,7 +1039,7 @@ Returns the minimum bounding rectangle of a geometry.
 
 **Return**
 
-- Minumum bounding rectangle
+- Minimum bounding rectangle
 
 
 **See also**
@@ -1519,7 +1519,7 @@ Get the Z coordinate of a Point geometry.
 
 **Return**
 
-- For a TG_POINT geometry, returns the Z coodinate.
+- For a TG_POINT geometry, returns the Z coordinate.
 - For everything else returns zero.
 
 
@@ -1539,7 +1539,7 @@ Get the M coordinate of a Point geometry.
 
 **Return**
 
-- For a TG_POINT geometry, returns the M coodinate.
+- For a TG_POINT geometry, returns the M coordinate.
 - For everything else returns zero.
 
 
@@ -1565,7 +1565,7 @@ Get the extra coordinates for a geometry.
 
 **Note**
 
-- These are the raw coodinates provided by a constructor like [tg_geom_new_polygon_z()](#group___geometry_constructors_ex_1gac81514f9acbafce335d8982233772664) or from a parsed source like WKT "POLYGON Z ...".
+- These are the raw coordinates provided by a constructor like [tg_geom_new_polygon_z()](#group___geometry_constructors_ex_1gac81514f9acbafce335d8982233772664) or from a parsed source like WKT "POLYGON Z ...".
 
 
 **See also**
@@ -1832,7 +1832,7 @@ struct tg_geom *tg_parse_geojson(const char *geojson);
 ```
 Parse geojson.
 
-Supports [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) standard, including Features, FeaturesCollection, ZM coordinates, properties, and arbritary JSON members. 
+Supports [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) standard, including Features, FeaturesCollection, ZM coordinates, properties, and arbitrary JSON members. 
 
 **Parameters**
 
@@ -2470,7 +2470,7 @@ The content is stored as a C string in the buffer pointed to by dst. A terminati
 
 **Return**
 
-- The number of characters, not including the null-terminator, needed to store the content into the C string buffer. If the returned length is greater than n-1, then only a parital copy occurred, for example:
+- The number of characters, not including the null-terminator, needed to store the content into the C string buffer. If the returned length is greater than n-1, then only a partial copy occurred, for example:
 ```c
 char str[64];
 size_t len = tg_geom_geojson(geom, str, sizeof(str));
@@ -2512,7 +2512,7 @@ The content is stored as a C string in the buffer pointed to by dst. A terminati
 
 **Return**
 
-- The number of characters, not including the null-terminator, needed to store the content into the C string buffer. If the returned length is greater than n-1, then only a parital copy occurred, for example:
+- The number of characters, not including the null-terminator, needed to store the content into the C string buffer. If the returned length is greater than n-1, then only a partial copy occurred, for example:
 ```c
 char str[64];
 size_t len = tg_geom_wkt(geom, str, sizeof(str));
@@ -2554,7 +2554,7 @@ The content is stored in the buffer pointed by dst.
 
 **Return**
 
-- The number of characters needed to store the content into the buffer. If the returned length is greater than n, then only a parital copy occurred, for example:
+- The number of characters needed to store the content into the buffer. If the returned length is greater than n, then only a partial copy occurred, for example:
 ```c
 uint8_t buf[64];
 size_t len = tg_geom_wkb(geom, buf, sizeof(buf));
@@ -2596,7 +2596,7 @@ The content is stored as a C string in the buffer pointed to by dst. A terminati
 
 **Return**
 
-- The number of characters, not including the null-terminator, needed to store the content into the C string buffer. If the returned length is greater than n-1, then only a parital copy occurred, for example:
+- The number of characters, not including the null-terminator, needed to store the content into the C string buffer. If the returned length is greater than n-1, then only a partial copy occurred, for example:
 ```c
 char str[64];
 size_t len = tg_geom_hex(geom, str, sizeof(str));
@@ -2638,7 +2638,7 @@ The content is stored in the buffer pointed by dst.
 
 **Return**
 
-- The number of characters needed to store the content into the buffer. If the returned length is greater than n, then only a parital copy occurred, for example:
+- The number of characters needed to store the content into the buffer. If the returned length is greater than n, then only a partial copy occurred, for example:
 ```c
 uint8_t buf[64];
 size_t len = tg_geom_geobin(geom, buf, sizeof(buf));
@@ -3716,7 +3716,7 @@ Returns the minimum bounding rectangle of a rect.
 
 **Return**
 
-- Minimum bounding retangle
+- Minimum bounding rectangle
 
 
 **See also**
@@ -4075,7 +4075,7 @@ Iterates over all segments in ring A that intersect with segments in line B.
 
 **Note**
 
-- This efficently uses the indexes of each geometry, if available.
+- This efficiently uses the indexes of each geometry, if available.
 
 
 **See also**
@@ -4093,7 +4093,7 @@ Iterates over all segments in ring A that intersect with segments in ring B.
 
 **Note**
 
-- This efficently uses the indexes of each geometry, if available.
+- This efficiently uses the indexes of each geometry, if available.
 
 
 **See also**
@@ -4601,7 +4601,7 @@ Iterates over all segments in line A that intersect with segments in line B.
 
 **Note**
 
-- This efficently uses the indexes of each geometry, if available.
+- This efficiently uses the indexes of each geometry, if available.
 
 
 **See also**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -155,7 +155,7 @@ geos/none            63,730    15691   10000  2298    47.45 µs    240,168
 geos/prepared       120,078     8328   10000  2298   669.48 µs    764,696
 
 <b>== Line intersect ==</b>
-Benchmark line interecting polygon operation for 10K random line
+Benchmark line intersecting polygon operation for 10K random line
 segments that are each no larger than 10% the width of the polygon
 and are within the polygon's MBR plus an extra 10% padding.
 Performs 10 runs and chooses the best results.

--- a/docs/GEOBIN.md
+++ b/docs/GEOBIN.md
@@ -92,7 +92,7 @@ It's required that when provided the extra json is valid json.
 ### 0x01: Point WKB
 
 When the head byte is 0x01, the entire binary is a WKB Point.
-The MBR must be cacluated from the WKB, which shouldn't be too difficult since
+The MBR must be calculated from the WKB, which shouldn't be too difficult since
 the WKB has its own head byte specifying dimensionality.
 
 ### 0x02: Non-point Geometry

--- a/docs/POLYGON_INDEXING.md
+++ b/docs/POLYGON_INDEXING.md
@@ -36,7 +36,7 @@ The speedup can be dramatic. Effectively turning an O(n) operation into an [O(lo
 
 Yet the downside of straight-up using an R-tree in its traditional format is that the construction time is slow and the index can use a lot of memory.
 
-This is because constructing an R-tree usually requires organizing the segments in such a way to make for efficent searching. This organizing usually consists of sorting the segments into leaf nodes and creating subsequent branch nodes. Sorting is slow, and storing all this node data will result in a lot of extra memory being used. Sometimes more than double the size of the original polygon itself.
+This is because constructing an R-tree usually requires organizing the segments in such a way to make for efficient searching. This organizing usually consists of sorting the segments into leaf nodes and creating subsequent branch nodes. Sorting is slow, and storing all this node data will result in a lot of extra memory being used. Sometimes more than double the size of the original polygon itself.
 
 The next two sections introduce the [Natural](#natural) and [YStripes](#ystripes) structures, and address the issue of construction time, memory usage, and search performance.
 

--- a/docs/assets/API_head.md
+++ b/docs/assets/API_head.md
@@ -10,7 +10,7 @@ For a more general overview please see the project
 
 ## Table of contents
 
-- [Programing notes](#programing-notes)
+- [Programming notes](#programing-notes)
 - [Structs](#structs)
 - [Objects](#objects)
 - [Enums](#enums)
@@ -28,7 +28,7 @@ For a more general overview please see the project
 - [Polygon functions](#polygon-functions)
 - [Global environment](#global-environment)
 
-## Programing notes
+## Programming notes
 
 #### Pure functions
 

--- a/tests/bench.c
+++ b/tests/bench.c
@@ -127,7 +127,7 @@ static void bench_step_geos(
 
     GEOSContextHandle_t handle = GEOS_init_r();
 
-    // convers rand tg points into geos points
+    // converts rand tg points into geos points
     GEOSGeometry **rgeoms = malloc(N*sizeof(GEOSGeometry *));
     assert(rgeoms);
     memset(rgeoms, 0, N*sizeof(GEOSGeometry *));
@@ -392,7 +392,7 @@ void intersects_bench(const char *name, int runs, const struct tg_point points[]
     // create a rect from the incoming points.
     struct tg_rect rect = rect_from_points(points, npoints);
 
-    // create random segments that are conatined in or intersecting the rect.
+    // create random segments that are contained in or intersecting the rect.
     struct tg_segment *rsegs = make_random_segments(rect, N);
 
     bench_run(runs, name, "tg", "none", points, npoints, 0, rsegs, N);
@@ -558,7 +558,7 @@ void main_intersects_bench(uint64_t seed, int runs) {
     print_start_bold();
     printf("== Line intersect ==");
     print_end_bold();
-    printf("Benchmark line interecting polygon operation for 10K random line\n"
+    printf("Benchmark line intersecting polygon operation for 10K random line\n"
            "segments that are each no larger than %d%% the width of the polygon\n"
            "and are within the polygon's MBR plus an extra %.0f%% padding.\n",
            NUM_RAND_SEGMENTS/1000, MBR_PAD*100.0);

--- a/tests/test_index.c
+++ b/tests/test_index.c
@@ -390,7 +390,7 @@ void test_index_ystripes_circle(void) {
         }
     }
     if (hits < 7700 || hits > 8000) {
-        fprintf(stderr, "exected between 7700-8000, got: %d\n", hits);
+        fprintf(stderr, "expected between 7700-8000, got: %d\n", hits);
         assert(0);
     }
     free(points);

--- a/tests/test_wkb.c
+++ b/tests/test_wkb.c
@@ -87,7 +87,7 @@ struct tg_geom *__any_parse(int line, const char *input, bool oom) {
     }
     tg_geom_hex(geom, buf2, sizeof(buf2));
     if (strcmp(buf1, buf2) != 0) {
-        printf("line %d: hex reencode mismatch: expected:\n\t%s\n"
+        printf("line %d: hex re-encode mismatch: expected:\n\t%s\n"
             "got:\n\t%s\n\n", line, buf1, buf2);
         abort();
     }

--- a/tests/tests.h
+++ b/tests/tests.h
@@ -444,7 +444,7 @@ bool segeq(struct tg_segment a, struct tg_segment b) {
 }
 
 // eqish should only be used for comparing calculations like distance or area.
-// Spefically for meters where you need cm accuracy
+// Specifically for meters where you need cm accuracy
 bool eqish(double a, double b) {
     return fabs(a-b) < 0.001;
 }

--- a/tg.c
+++ b/tg.c
@@ -686,7 +686,7 @@ struct multi {
 /// LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, or 
 /// GeometryCollection. 
 /// 
-/// For geometries that are derived from GeoJSON, they may have addtional 
+/// For geometries that are derived from GeoJSON, they may have additional 
 /// attributes such as being a Feature or a FeatureCollection; or include
 /// extra json fields.
 ///
@@ -732,7 +732,7 @@ struct tg_geom {
             double m;
         };
         struct {  // !TG_POINT
-            double *coords; // extra dimensinal coordinates
+            double *coords; // extra dimensional coordinates
             int ncoords;
         };
     };
@@ -2000,7 +2000,7 @@ static struct tg_rect process_points(const struct tg_point *points,
     // - Wrapped is the remaining loop steps, up to three.
     //
     // Finally, there is a Convex and Concave section.
-    // - Convex is the initial state. Each step will do some calcuations until
+    // - Convex is the initial state. Each step will do some calculations until
     //   it is determined if the ring is concave. Once it's known to be concave
     //   the code jumps to the Concave section.
     // - Concave section is just like the Convex section, but there is no
@@ -2332,7 +2332,7 @@ int tg_ring_num_points(const struct tg_ring *ring) {
 
 /// Returns the minimum bounding rectangle of a rect.
 /// @param ring Input ring
-/// @returns Minimum bounding retangle
+/// @returns Minimum bounding rectangle
 /// @see RingFuncs
 struct tg_rect tg_ring_rect(const struct tg_ring *ring) {
     if (!ring) return (struct tg_rect){ 0 };
@@ -2564,7 +2564,7 @@ static bool ring_ring_ix(const struct tg_ring *a, int alvl, int aidx,
 }
 
 /// Iterates over all segments in ring A that intersect with segments in ring B.
-/// @note This efficently uses the indexes of each geometry, if available.
+/// @note This efficiently uses the indexes of each geometry, if available.
 /// @see RingFuncs
 void tg_ring_ring_search(const struct tg_ring *a, const struct tg_ring *b, 
     bool (*iter)(struct tg_segment aseg, int aidx, struct tg_segment bseg, 
@@ -2617,7 +2617,7 @@ void tg_ring_ring_search(const struct tg_ring *a, const struct tg_ring *b,
 }
 
 /// Iterates over all segments in line A that intersect with segments in line B.
-/// @note This efficently uses the indexes of each geometry, if available.
+/// @note This efficiently uses the indexes of each geometry, if available.
 /// @see LineFuncs
 void tg_line_line_search(const struct tg_line *a, const struct tg_line *b, 
     bool (*iter)(struct tg_segment aseg, int aidx, struct tg_segment bseg, 
@@ -2628,7 +2628,7 @@ void tg_line_line_search(const struct tg_line *a, const struct tg_line *b,
 }
 
 /// Iterates over all segments in ring A that intersect with segments in line B.
-/// @note This efficently uses the indexes of each geometry, if available.
+/// @note This efficiently uses the indexes of each geometry, if available.
 /// @see RingFuncs
 void tg_ring_line_search(const struct tg_ring *a, const struct tg_line *b, 
     bool (*iter)(struct tg_segment aseg, int aidx, struct tg_segment bseg, 
@@ -3596,7 +3596,7 @@ bool tg_line_covers_poly(const struct tg_line *line,
     struct tg_rect rect = tg_poly_rect(poly);
     if (rect.min.x != rect.max.x && rect.min.y != rect.max.y) return false;
     
-    // polygon can fit in a straight (vertial or horizontal) line
+    // polygon can fit in a straight (vertical or horizontal) line
     struct tg_segment seg = { rect.min, rect.max };
     struct tg_ring *other = stack_ring();
     segment_to_ring(seg, other);
@@ -5193,7 +5193,7 @@ static struct tg_rect geom_rect(const struct tg_geom *geom) {
 
 /// Returns the minimum bounding rectangle of a geometry.
 /// @param geom Input geometry
-/// @return Minumum bounding rectangle
+/// @return Minimum bounding rectangle
 /// @see tg_rect
 /// @see GeometryAccessors
 struct tg_rect tg_geom_rect(const struct tg_geom *geom) {
@@ -6552,7 +6552,7 @@ bool tg_geom_intersects_xy(const struct tg_geom *a, double x, double y) {
 /// @param geom Input geometry
 /// @return Array of coordinates
 /// @return NULL if there are no extra coordinates 
-/// @note These are the raw coodinates provided by a constructor like 
+/// @note These are the raw coordinates provided by a constructor like 
 /// tg_geom_new_polygon_z() or from a parsed source like WKT "POLYGON Z ...".
 /// @see tg_geom_num_extra_coords()
 const double *tg_geom_extra_coords(const struct tg_geom *geom) {
@@ -6603,7 +6603,7 @@ bool tg_geom_has_m(const struct tg_geom *geom) {
 
 /// Get the Z coordinate of a Point geometry.
 /// @param geom Input geometry
-/// @return For a TG_POINT geometry, returns the Z coodinate.
+/// @return For a TG_POINT geometry, returns the Z coordinate.
 /// @return For everything else returns zero.
 double tg_geom_z(const struct tg_geom *geom) {
     if (!geom || geom->head.base != BASE_GEOM || geom->head.type != TG_POINT) {
@@ -6614,7 +6614,7 @@ double tg_geom_z(const struct tg_geom *geom) {
 
 /// Get the M coordinate of a Point geometry.
 /// @param geom Input geometry
-/// @return For a TG_POINT geometry, returns the M coodinate.
+/// @return For a TG_POINT geometry, returns the M coordinate.
 /// @return For everything else returns zero.
 double tg_geom_m(const struct tg_geom *geom) {
     if (!geom || geom->head.base != BASE_GEOM || geom->head.type != TG_POINT) {
@@ -8640,7 +8640,7 @@ struct tg_geom *tg_parse_geojsonn(const char *geojson, size_t len) {
 ///
 /// Supports [GeoJSON](https://datatracker.ietf.org/doc/html/rfc7946) standard,
 /// including Features, FeaturesCollection, ZM coordinates, properties, and
-/// arbritary JSON members.
+/// arbitrary JSON members.
 /// @param geojson A geojson string. Must be UTF8 and null-terminated.
 /// @returns A geometry or an error. Use tg_geom_error() after parsing to check
 /// for errors. 
@@ -11243,7 +11243,7 @@ static size_t fp_utoa(union fpoint fpoint, int bits, char fmt,
 ///
 /// Returns the number of characters, not including the null-terminator, needed
 /// to store the double into the C string buffer.
-/// If the returned length is greater than nbytes-1, then only a parital copy
+/// If the returned length is greater than nbytes-1, then only a partial copy
 /// occurred.
 /// 
 /// The format is one of 
@@ -11263,7 +11263,7 @@ FP_EXTERN size_t fp_dtoa(double d, char fmt, char dst[], size_t n) {
 ///
 /// Returns the number of characters, not including the null-terminator, needed
 /// to store the float into the C string buffer.
-/// If the returned length is greater than nbytes-1, then only a parital copy
+/// If the returned length is greater than nbytes-1, then only a partial copy
 /// occurred.
 /// 
 /// The format is one of 
@@ -11876,7 +11876,7 @@ static void write_geom_geojson(const struct tg_geom *geom, struct writer *wr) {
 /// @param n Maximum number of bytes to be used in the buffer.
 /// @return  The number of characters, not including the null-terminator, 
 /// needed to store the content into the C string buffer.
-/// If the returned length is greater than n-1, then only a parital copy
+/// If the returned length is greater than n-1, then only a partial copy
 /// occurred, for example:
 ///
 /// ```
@@ -12163,7 +12163,7 @@ static int parse_wkt_posns(enum base base, int dims, int depth, const char *wkt,
             }
             i = wkt_trim_ws(wkt, len, i+1);
         }
-        // read each number, delimted by whitespace
+        // read each number, delimited by whitespace
         while (i < len) {
             double num;
             if (isnum(wkt[i])) {
@@ -13251,7 +13251,7 @@ static void write_geom_wkt(const struct tg_geom *geom, struct writer *wr) {
 /// @param n Maximum number of bytes to be used in the buffer.
 /// @return  The number of characters, not including the null-terminator, 
 /// needed to store the content into the C string buffer.
-/// If the returned length is greater than n-1, then only a parital copy
+/// If the returned length is greater than n-1, then only a partial copy
 /// occurred, for example:
 ///
 /// ```
@@ -14427,7 +14427,7 @@ static void write_geom_wkb(const struct tg_geom *geom, struct writer *wr) {
 /// @param n Maximum number of bytes to be used in the buffer.
 /// @return  The number of characters needed to store the content into the
 /// buffer.
-/// If the returned length is greater than n, then only a parital copy
+/// If the returned length is greater than n, then only a partial copy
 /// occurred, for example:
 ///
 /// ```
@@ -14460,7 +14460,7 @@ size_t tg_geom_wkb(const struct tg_geom *geom, uint8_t *dst, size_t n) {
 /// @param n Maximum number of bytes to be used in the buffer.
 /// @return  The number of characters, not including the null-terminator, 
 /// needed to store the content into the C string buffer.
-/// If the returned length is greater than n-1, then only a parital copy
+/// If the returned length is greater than n-1, then only a partial copy
 /// occurred, for example:
 ///
 /// ```
@@ -15736,7 +15736,7 @@ static void write_geom_geobin(const struct tg_geom *geom, struct writer *wr) {
 /// @param n Maximum number of bytes to be used in the buffer.
 /// @return  The number of characters needed to store the content into the
 /// buffer.
-/// If the returned length is greater than n, then only a parital copy
+/// If the returned length is greater than n, then only a partial copy
 /// occurred, for example:
 ///
 /// ```

--- a/tg.h
+++ b/tg.h
@@ -27,7 +27,7 @@ struct tg_segment {
 
 /// A rectangle defined by a minimum and maximum coordinates.
 /// Returned by the tg_geom_rect(), tg_ring_rect(), and other \*_rect() 
-/// functions for getting a geometry's minumum bounding rectangle.
+/// functions for getting a geometry's minimum bounding rectangle.
 /// Also used internally for geometry indexing.
 /// @see RectFuncs
 struct tg_rect {


### PR DESCRIPTION
This fixes a handful of typos, mostly identified and automated using [codespell](https://github.com/codespell-project/codespell).

I can add a codespell configuration to this PR if interested in guarding against future typos.